### PR TITLE
docs: humanize README and streamline feature overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,40 +4,26 @@
 
 # Lego-RL
 
-**Online RL for real coding agents — in their native harnesses, on real repositories.**
+**Online reinforcement learning for coding agents in their native harnesses and real repositories.**
 
 [![arXiv](https://img.shields.io/badge/arXiv-2608.17393-b31b1b?logo=arxiv&logoColor=white)](https://arxiv.org/abs/2608.17393)
 [![Docs](https://img.shields.io/badge/docs-lego--rl.pages.dev-2563eb?logo=readthedocs&logoColor=white)](https://lego-rl.pages.dev)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 [![verl](https://img.shields.io/badge/built%20on-verl-orange)](https://github.com/verl-project/verl)
-[![Harbor](https://img.shields.io/badge/built%20on-Harbor-8b5cf6)](https://github.com/SWE-Lego/harbor)
+[![Harbor](https://img.shields.io/badge/built%20on-Harbor-8b5cf6)](https://github.com/LegoX/harbor)
 
 **[Documentation](https://lego-rl.pages.dev)** · **[Getting Started](https://lego-rl.pages.dev/docs/getting-started)** · **[Why Lego-RL](https://lego-rl.pages.dev/docs/why-lego-rl)**
 
 </div>
 
-Lego-RL is an open-source framework for reinforcement learning of **coding agents in their own
-harnesses**. It connects agents such as **OpenHands**, **Claude Code** and **OpenCode**
-to scalable policy-gradient training (PPO / GRPO / GSPO) while preserving their original control flow
-and their exact rollout trajectories.
+Lego-RL is an open-source framework for training coding agents with online reinforcement learning on
+real software-engineering tasks. It connects **Claude Code**, **OpenHands**, **OpenCode**, and
+**Terminus** to [verl](https://github.com/verl-project/verl) while keeping each agent's native
+control flow.
 
-It integrates [**verl**](https://github.com/verl-project/verl) (trainer + rollout) with
-[**Harbor**](https://github.com/SWE-Lego/harbor) (sandboxed task execution + verifier reward): the agent
-solves a real issue in a real repository inside a fresh sandbox, the task's own test suite produces the
-reward, and the trainer turns the scored trajectory into a gradient step.
-
-Lego-RL is **faithful** with:
-
-- **Unmodified agent harnesses**: each scaffold is a thin adapter, not a fork. The control flow that produced a rollout is the control flow you deploy.
-- **Generation-time trajectory capture**: token ids, masks and log-probabilities are recorded inside the serving path by an in-process proxy — nothing is re-tokenized from a rendered transcript.
-- **Executable rewards**: each task's own test suite runs in a fresh sandbox and its exit status is the reward — no reference-patch similarity, no model judge.
-- **Rollout/training consistency on sparse models**: rollout-time expert routing is recorded and replayed during the update, holding rollout-vs-training log-prob correlation at `pearson ≈ 0.999`.
-
-Lego-RL is **production-ready** with:
-
-- **Scale-out sandboxes**: Kubernetes (inline build, nydus image cache, agent-runtime image mounting) or plain local/remote Docker, thousands of task containers per run.
-- **Fully-async training**: partial rollout and staleness control keep GPUs busy while long agent trajectories finish.
-- **Observability first**: validate a run before any GPU is committed, then diagnose it from metrics, termination causes and full agent trajectories in a live dashboard.
+Each run follows the same loop: an agent works on a repository task in a fresh
+[Harbor](https://github.com/LegoX/harbor) sandbox, the task's verifier supplies the reward, and verl
+updates the policy from the captured trajectory.
 
 <div align="center">
  <img src="docs/public/framework.png" width="820" alt="Lego-RL architecture">
@@ -45,38 +31,50 @@ Lego-RL is **production-ready** with:
 
 ## Live Training Dashboard
 
-Lego-RL includes a self-contained [training dashboard](https://lego-rl.pages.dev/docs/dashboard) for monitoring reward and score, entropy, KL, clip fraction, sequence lengths, MFU, throughput, asynchronous rollout health, and validation throughout an RL run. It can read local training logs directly or load metrics from Weights & Biases, with side-by-side run comparison and per-task solve-rate views.
+Lego-RL includes a self-contained [training dashboard](https://lego-rl.pages.dev/docs/dashboard) for
+following a run as it progresses. It shows reward, score, entropy, KL, sequence lengths, MFU,
+throughput, asynchronous rollout health, validation, and per-task solve rates. The dashboard reads
+local training logs and can also load runs from Weights & Biases.
 
-The trajectory browser connects aggregate metrics back to individual Harbor trials, including the problem statement, agent reasoning, tool calls and observations, token usage, timing, termination status, and verifier reward.
+Its trajectory browser links these metrics to individual Harbor trials, including the task,
+reasoning, tool calls, observations, token usage, timing, termination status, and verifier reward.
 
 ```bash
 bash webui/start_dashboard.sh
 ```
 
-See an [example training diagnostic report](webui/demo_reports/harbor-oc-async-2n-20260526-232411.md) generated from a fully asynchronous OpenCode training run.
+See an [example training diagnostic report](webui/demo_reports/harbor-oc-async-2n-20260526-232411.md)
+from a fully asynchronous OpenCode training run.
 
 ## News
 
-- [2026/08] **First public release.** Lego-RL trains real coding agents — OpenHands, Claude Code, OpenCode — in their own unmodified harnesses on real repositories: token ids, masks and log-probabilities are captured inside the serving path by an in-process proxy, and the reward is each task's own test suite run in a fresh sandbox. Kubernetes (thousands of task containers per run) or plain Docker, synchronous or fully-async.
+- [2026/08] **First public release.** Lego-RL brings Claude Code, OpenHands, OpenCode, and Terminus
+  into online RL on real repositories, with native harnesses, executable verifier rewards,
+  synchronous or asynchronous training, and live run monitoring.
 
 ## Key Features
 
-- **Agents**: OpenHands (`openhands-sdk` / `openhands-ai`), Claude Code, OpenCode — all driving the *same* model being trained. Any harness speaking the OpenAI or Anthropic API can be added as a [custom adapter](https://lego-rl.pages.dev/docs/architecture/agent-loop-workers#agent-loop-classes).
-- **Algorithms**: PPO, GRPO, GSPO, with token-level / sequence-level importance sampling, adaptive KL, and trajectory filtering by `termination_reason` (broken or over-long trajectories are dropped from the *loss*, not the batch).
-- **Training backends**: FSDP, Megatron-LM and **VeOmni**; synchronous single- and multi-node, or **fully-async** with partial rollout and staleness control.
-- **Rollout**: vLLM behind an [in-process proxy](https://lego-rl.pages.dev/docs/architecture/in-process-proxy) serving both the OpenAI and Anthropic `/v1/messages` surfaces, with exact token/logprob capture, prefix-mismatch recovery for harnesses that rewrite their own history, and a [global load balancer](https://lego-rl.pages.dev/docs/architecture/global-load-balancer) with sticky session routing.
-- **MoE**: R3 routing replay for Qwen3-MoE / Qwen3.5, expert parallelism, and a checkpoint merger with a mandatory key-set verifier.
-- **Sandbox backends**: [Kubernetes or Docker](https://lego-rl.pages.dev/docs/training-run/sandbox-backends), with prebuilt or inline-built per-task images, nydus lazy pull, and per-phase network policy.
-- **Reward**: each task's verifier suite, run in the sandbox, with [reward-hacking audits](https://lego-rl.pages.dev/docs/reference/reward-hacking) for task sets that leak their own answer.
-- **Data**: build a parquet [task index](https://lego-rl.pages.dev/docs/data/task-index) from Harbor task folders (SWE-bench-style or OpenSWE-style), with [sandbox image](https://lego-rl.pages.dev/docs/data/sandbox-images) build pipelines and difficulty filtering.
-- **Observability**: [run validation](https://lego-rl.pages.dev/docs/run-validation) before launch, a [live dashboard](https://lego-rl.pages.dev/docs/dashboard) over reward / entropy / KL / MFU / lengths / validation plus per-trial trajectories and their verifier reward, wandb-backed, publishable to Cloudflare Pages.
-- **No-patch integration**: all glue lives in `src/verl_patch` and `src/harbor_patch` — nothing is patched into upstream verl or Harbor.
-- **Optional agent plugin**: `/rl:check`, `/rl:run`, `/rl:status`, `/rl:dashboard` wrap the runners for [Claude Code](https://claude.com/claude-code) and Codex ([details](https://lego-rl.pages.dev/docs/reference/agent-plugin)) — convenience, never a requirement.
+- **Native agents**: Claude Code, OpenHands, OpenCode, and Terminus run through thin adapters. A
+  custom scaffold that speaks the OpenAI or Anthropic API can use the same [agent-loop interface](https://lego-rl.pages.dev/docs/architecture/agent-loop-workers#agent-loop-classes).
+- **Faithful rollouts**: an [in-process proxy](https://lego-rl.pages.dev/docs/architecture/in-process-proxy)
+  records token ids, masks, and log-probabilities at generation time. It also handles history
+  rewrites and serves the OpenAI and Anthropic interfaces used by the supported agents.
+- **RL and scaling**: PPO, GRPO, and GSPO run on FSDP, VeOmni, or Megatron, either synchronously or
+  fully asynchronously. MoE runs can use R3 routing replay, while trajectory filtering removes
+  broken or over-long rollouts from the loss.
+- **Sandboxed rewards**: [Kubernetes or Docker](https://lego-rl.pages.dev/docs/training-run/sandbox-backends)
+  runs each task in an isolated Harbor environment. The task verifier provides the reward, with
+  image caching and reward-hacking checks available for supported task sets.
+- **Data and operations**: task indexes, preflight validation, and the optional `/rl:check`,
+  `/rl:run`, `/rl:status`, and `/rl:dashboard` commands support the complete run lifecycle.
+- **Monitoring**: the [live dashboard](https://lego-rl.pages.dev/docs/dashboard) combines training
+  curves, validation, per-task results, and individual trajectories. The integration keeps the
+  project glue in `src/verl_patch` and `src/harbor_patch` rather than modifying upstream packages.
 
 ## Getting Started
 
 > [!TIP]
-> Everything — installation, configuration, the full loop, the failure playbook — is at
+> Everything from installation and configuration to the full training loop and failure playbook is at
 > **[lego-rl.pages.dev/docs](https://lego-rl.pages.dev/docs)**.
 
 Install and launch the [demo run](https://lego-rl.pages.dev/docs/demo), a real training run at
@@ -98,7 +96,7 @@ indexes, and a reachable Kubernetes cluster (`BACKEND=docker` drives one machine
 The validate step launches nothing. In Claude Code the same run is `/rl:run scripts/train/configs/demo.env`.
 
 > [!IMPORTANT]
-> `setup_env.sh` clones Harbor [`SWE-Lego/harbor`](https://github.com/SWE-Lego/harbor) @ `ydu_dev`
+> `setup_env.sh` clones Harbor [`LegoX/harbor`](https://github.com/LegoX/harbor) @ `ydu_dev`
 > (harbor `0.3.1`), which **is not public yet**, so that clone fails without access. `HARBOR_REF=main`
 > gets vanilla upstream (`0.1.45`) and works for everyone, minus the per-phase network-policy
 > framework, the OpenHands-SDK 1.33 runtime, the OpenSWE adapter and the git-history restore hook.
@@ -110,7 +108,7 @@ The validate step launches nothing. In Claude Code the same run is `/rl:run scri
 ## Acknowledgement
 
 Built on [verl](https://github.com/verl-project/verl) for RL training and
-[Harbor](https://github.com/SWE-Lego/harbor) for sandboxed task execution and verifier rewards.
+[Harbor](https://github.com/LegoX/harbor) for sandboxed task execution and verifier rewards.
 Coding agents: [Claude Code](https://github.com/anthropics/claude-code),
 [OpenHands](https://github.com/All-Hands-AI/OpenHands),
 and [OpenCode](https://github.com/sst/opencode).


### PR DESCRIPTION
## 修改内容

本 PR 只修改 `README.md`，不涉及代码、文档源文件或其他资源。

- 调整 README 的英文表达，使语气更自然、易读，移除 em dash（`—`）并修正不完整或不自然的并列句。
- 保留 `News` 和 `Key Features`，同时压缩重复内容。
- 将原有 feature 合并为 native agents、faithful rollouts、RL and scaling、sandboxed rewards、data and operations、monitoring 六类。
- 在开头更清楚地说明 Lego-RL 的训练闭环：原生 agent harness、in-process proxy、Harbor sandbox/verifier、verl trainer 和 dashboard。
- 保留现有的架构流程图 `docs/public/framework.png`。
- 将 README 中的 Harbor 组织链接从 `SWE-Lego/harbor` 更新为 `LegoX/harbor`。
- 保留 dashboard 启动命令、文档链接和现有训练诊断报告链接。

## Dashboard 样例图

当前仓库没有真实的 W&B run、训练日志快照或 dashboard UI 截图，因此本 PR 没有加入会误导读者的伪造图片。README 仍保留现有流程图和 dashboard 文本入口。

建议后续提供脱敏的 W&B run、训练日志或 dashboard snapshot，再加入真实的训练监控样例图。

## 检查

- README 中不再包含 `—`。
- README 中不再包含 `SWE-Lego`。
- `News`、`Key Features` 和 `docs/public/framework.png` 均保留。
- 分支相对 `main` 只包含 README 修改。