### PR TITLE
feat: add codex skills for Lego-RL operations

### DIFF
--- a/.agents/skills/lego-rl-config/SKILL.md
+++ b/.agents/skills/lego-rl-config/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lego-rl-config
-description: Compose, edit, refactor, and validate Lego-RL train/eval/infer .env configs and reusable scripts/templates modules. Use when Codex is asked to generate an experiment config, migrate legacy wrappers into configs, edit template modules, dry-run a train/eval/infer workload, or explain the runner/template/site-env contract for this repository.
+description: Compose, edit, refactor, and validate Lego-RL train/eval/infer .env configs and reusable scripts/templates modules. Use when Codex is asked to generate an experiment config, migrate legacy wrappers into configs, edit template modules, dry-run a train/eval/infer workload for config validation, or explain the runner/template/site-env contract. For Claude-style operational commands use the one-to-one Codex counterparts $rl-check, $rl-run, $rl-status, $rl-dashboard, and $rl-k8s-sandbox-install.
 ---
 
 # Lego-RL Config
@@ -13,6 +13,17 @@ This skill follows the Claude `/rl:*` plugin's layering rule:
 
 > Scripts own deterministic behavior. Skills own orchestration, judgement, and
 > the final report.
+
+## Related Operational Skills
+
+Use this skill for config and template work. Use the one-to-one Codex
+counterparts for Claude plugin operations:
+
+- `$rl-check` for `/rl:check`
+- `$rl-run` for `/rl:run`
+- `$rl-status` for `/rl:status`
+- `$rl-dashboard` for `/rl:dashboard`
+- `$rl-k8s-sandbox-install` for `/rl:k8s-sandbox-install`
 
 ## Start Here
 

--- a/.agents/skills/rl-check/SKILL.md
+++ b/.agents/skills/rl-check/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: rl-check
+description: One-to-one Codex counterpart for Claude `/rl:check`. Preflight a Lego-RL train, eval, or infer config and answer whether it is safe to launch right now. Use when the user asks to check, preflight, validate, review launch readiness, list resolved run parameters, or asks `/rl:check config`.
+---
+
+# RL Check
+
+Use this skill as the Codex entrypoint corresponding to Claude `/rl:check`.
+
+Before taking task actions, read the canonical workflow in
+`.claude/plugins/rl-plugin/skills/check/SKILL.md` completely and follow it as
+the source of truth. Treat this file as a thin adapter for Codex skill
+discovery, not a replacement for the detailed rules there.
+
+## Invocation Mapping
+
+- Claude: `/rl:check config`
+- Codex: `$rl-check` or natural language such as "check this config",
+  "preflight this run", "can I launch this run", or "validate the config".
+
+## Codex Notes
+
+Find the Lego-RL repo root first. It must contain
+`scripts/lib/preflight.sh`, `scripts/lib/live_probe.sh`, and the `.claude`
+plugin path above.
+
+Follow the Claude skill's layering rule:
+
+- scripts own deterministic behavior
+- this skill owns orchestration, live-host judgement, and the final report
+
+Remain read-only. Do not edit configs, launch workloads, kill processes, clear
+shared memory, delete logs, SSH to other nodes, or mutate cluster state.

--- a/.agents/skills/rl-check/agents/openai.yaml
+++ b/.agents/skills/rl-check/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "RL Check"
+  short_description: "Preflight a Lego-RL run config"
+  default_prompt: "Use $rl-check to preflight a Lego-RL config and report whether it is safe to launch."

--- a/.agents/skills/rl-dashboard/SKILL.md
+++ b/.agents/skills/rl-dashboard/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: rl-dashboard
+description: One-to-one Codex counterpart for Claude `/rl:dashboard`. Start or diagnose the Lego-RL webui dashboard on the current machine; choose log directories, port, frontend build state, existing instances, and optional Cloudflare quick tunnel after confirmation. Use when the user asks to start, deploy, expose, fix, or diagnose the dashboard/webui, missing curves, empty board, tunnel 502, or asks `/rl:dashboard [log-dir]`.
+---
+
+# RL Dashboard
+
+Use this skill as the Codex entrypoint corresponding to Claude
+`/rl:dashboard`.
+
+Before taking task actions, read the canonical workflow in
+`.claude/plugins/rl-plugin/skills/dashboard/SKILL.md` completely and follow it
+as the source of truth.
+
+## Invocation Mapping
+
+- Claude: `/rl:dashboard [log-dir]`
+- Codex: `$rl-dashboard` or natural language such as "start the dashboard",
+  "deploy the webui", "bring the dashboard up", "the dashboard will not open",
+  "tunnel 502", "why does this run have no curves", or "training curves not
+  showing".
+
+## Codex Notes
+
+Find the Lego-RL repo root first. It must contain `webui/server.py`,
+`scripts/lib/dashboard_probe.sh`, and the `.claude` plugin path above.
+
+Never open a public tunnel, start a new background server, rebuild frontend
+assets, or create symlinks without the confirmations required by the canonical
+workflow. Do not kill existing servers or tunnels that this conversation did
+not start.

--- a/.agents/skills/rl-dashboard/agents/openai.yaml
+++ b/.agents/skills/rl-dashboard/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "RL Dashboard"
+  short_description: "Start or diagnose the Lego-RL webui"
+  default_prompt: "Use $rl-dashboard to bring up the Lego-RL dashboard and report the URL."

--- a/.agents/skills/rl-k8s-sandbox-install/SKILL.md
+++ b/.agents/skills/rl-k8s-sandbox-install/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: rl-k8s-sandbox-install
+description: One-to-one Codex counterpart for Claude `/rl:k8s-sandbox-install`. Guided install or scale-out of a sandbox Kubernetes cluster for the Lego-RL k8s backend, using probes before decisions and confirmations for risky mutations. Use when the user asks to install Kubernetes, set up a cluster, add or join worker nodes, create a sandbox cluster, prepare kubeadm/containerd/flannel/ImageVolume, or asks `/rl:k8s-sandbox-install`.
+---
+
+# RL K8s Sandbox Install
+
+Use this skill as the Codex entrypoint corresponding to Claude
+`/rl:k8s-sandbox-install`.
+
+Before taking task actions, read the canonical workflow in
+`.claude/plugins/rl-plugin/skills/k8s-sandbox-install/SKILL.md` completely and
+follow it as the source of truth.
+
+## Invocation Mapping
+
+- Claude: `/rl:k8s-sandbox-install`
+- Codex: `$rl-k8s-sandbox-install` or natural language such as "install
+  kubernetes", "set up a cluster", "add a worker node", "join worker",
+  "new cluster", or "sandbox cluster deployment".
+
+## Codex Notes
+
+Find the Lego-RL repo root first. It must contain
+`scripts/lib/site.example.env`, the training runners, and the `.claude` plugin
+path above.
+
+Probe before deciding. Ask only for information that cannot be discovered
+safely, usually how to reach the target nodes over SSH. Any `kubeadm reset`,
+edit to an existing `/etc/kubernetes`, package install, service mutation, or
+operation touching a cluster someone else may be using requires explicit user
+confirmation and, where needed, sandbox escalation approval.
+
+Generate a new `scripts/lib/site.<name>.env` rather than overwriting the default
+`site.env`.

--- a/.agents/skills/rl-k8s-sandbox-install/agents/openai.yaml
+++ b/.agents/skills/rl-k8s-sandbox-install/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "RL K8s Sandbox Install"
+  short_description: "Install Lego-RL sandbox Kubernetes"
+  default_prompt: "Use $rl-k8s-sandbox-install to probe machines and prepare a Lego-RL Kubernetes sandbox."

--- a/.agents/skills/rl-run/SKILL.md
+++ b/.agents/skills/rl-run/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: rl-run
+description: One-to-one Codex counterpart for Claude `/rl:run`. Preflight and launch a Lego-RL train, eval, or infer run only after blocking checks pass, resolved parameters are shown, and the user explicitly confirms. Use when the user asks to launch, run, start, kick off training/eval/infer, get a config running, or asks `/rl:run config`.
+---
+
+# RL Run
+
+Use this skill as the Codex entrypoint corresponding to Claude `/rl:run`.
+
+Before taking task actions, read the canonical workflow in
+`.claude/plugins/rl-plugin/skills/run/SKILL.md` completely and follow it as the
+source of truth. That workflow depends on the `/rl:check` behavior; if needed,
+also read `.claude/plugins/rl-plugin/skills/check/SKILL.md`.
+
+## Invocation Mapping
+
+- Claude: `/rl:run config`
+- Codex: `$rl-run` or natural language such as "launch this config",
+  "run harbor training", "start the eval", "kick off training", or "get this
+  config running".
+
+## Codex Notes
+
+Find the Lego-RL repo root first. It must contain
+`scripts/train/train.sh`, `scripts/eval/eval.sh`, `scripts/infer/infer.sh`, and
+the `.claude` plugin path above.
+
+Never launch without an explicit yes in the current conversation. Default to
+background launch when the user approves. For multi-node runs, print the
+per-node command; do not SSH to other nodes.
+
+Do not force past a blocking preflight, kill a live run, edit configs to make a
+launch pass, delete logs/checkpoints, or mutate the cluster.

--- a/.agents/skills/rl-run/agents/openai.yaml
+++ b/.agents/skills/rl-run/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "RL Run"
+  short_description: "Launch Lego-RL runs with confirmation"
+  default_prompt: "Use $rl-run to preflight and launch a Lego-RL config after explicit confirmation."

--- a/.agents/skills/rl-status/SKILL.md
+++ b/.agents/skills/rl-status/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: rl-status
+description: One-to-one Codex counterpart for Claude `/rl:status`. Diagnose a Lego-RL run that is live or recently finished; identify the run, locate the real log, report progress, inspect metrics, and match known failure signatures. Use when the user asks how a run is doing, what step it is on, whether reward is improving, whether a run is broken, or asks `/rl:status`.
+---
+
+# RL Status
+
+Use this skill as the Codex entrypoint corresponding to Claude `/rl:status`.
+
+Before taking task actions, read the canonical workflow in
+`.claude/plugins/rl-plugin/skills/status/SKILL.md` completely and follow it as
+the source of truth.
+
+## Invocation Mapping
+
+- Claude: `/rl:status`
+- Codex: `$rl-status` or natural language such as "how's the run doing",
+  "what step is it on", "is reward going up", "is this run broken", or
+  "diagnose the training run".
+
+## Codex Notes
+
+Find the Lego-RL repo root first. It must contain
+`scripts/lib/live_probe.sh` and the `.claude` plugin path above.
+
+Remain read-only. Do not kill, restart, clean, rotate, edit configs, delete
+logs, SSH to other nodes, or mutate Kubernetes. When evidence points off-box,
+report the symptom and the node or layer to confirm rather than asserting a
+cause you cannot observe locally.

--- a/.agents/skills/rl-status/agents/openai.yaml
+++ b/.agents/skills/rl-status/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "RL Status"
+  short_description: "Diagnose live Lego-RL run health"
+  default_prompt: "Use $rl-status to diagnose the current Lego-RL run and summarize its health."


### PR DESCRIPTION
Add codex skills for Lego-RL operations, including rl-check, rl-dashboard, rl-k8s-sandbox-install, rl-run, and rl-status with detailed descriptions and invocation mappings