### PR TITLE
setup_env: point harbor at the ydu RL fork, not harbor-internal

### DIFF
--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -32,7 +32,14 @@ HARBOR_DIR="${HARBOR_DIR:-$THIRD_PARTY_DIR/harbor}"
 VERL_DIR="${VERL_DIR:-$THIRD_PARTY_DIR/verl}"
 VLLM_DIR="${VLLM_DIR:-$THIRD_PARTY_DIR/vllm}"
 
-HARBOR_REPO_URL="${HARBOR_REPO_URL:-https://github.com/LegoX/harbor-internal.git}"
+# harbor: the ydu RL fork, NOT LegoX/harbor-internal. The fork is harbor-internal
+# plus a thin RL layer, and this repo depends on two things that exist only there:
+# HARBOR_ENV_START_MAX_ATTEMPTS (trial.py) and BaseEnvironment.restore_git_history()
+# (the verifier-phase hook the anti-reward-hacking path calls). Pointing this at
+# harbor-internal installs cleanly and then misbehaves at run time, which is worse
+# than failing loudly. The fork tracks harbor-internal main; re-merge it there
+# rather than switching this URL back.
+HARBOR_REPO_URL="${HARBOR_REPO_URL:-https://github.com/Elvin-Yiming-Du/harbor.git}"
 HARBOR_REF="${HARBOR_REF:-${HARBOR_COMMIT:-main}}"
 
 VERL_REPO_URL="${VERL_REPO_URL:-https://github.com/verl-project/verl.git}"


### PR DESCRIPTION
The default sent setup_env at LegoX/harbor-internal, which is missing the RL layer this repo calls into: HARBOR_ENV_START_MAX_ATTEMPTS (trial.py) and BaseEnvironment.restore_git_history(). Neither exists on harbor-internal or on the public LegoX/harbor, so a fresh setup installed cleanly and then misbehaved at run time.

Elvin-Yiming-Du/harbor is harbor-internal plus that layer (5 files, +55/-8) and was just re-merged with harbor-internal main (4ded4e5), so this loses none of the internal work. Verified: the 88 HARBOR_* names this repo references have no case that the fork lacks and harbor-internal has.
