### PR TITLE
docs: add SAO and mixed-harness NEWS entries, move NEWS above the diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,17 @@ Each run follows the same loop: an agent works on a repository task in a fresh
 [Harbor](https://github.com/Elvin-Yiming-Du/harbor) sandbox, the task's verifier supplies the reward, and verl
 updates the policy from the captured trajectory.
 
+## News
+
+- [2026/09/11] **Mixed-harness training.** A single run can now interleave OpenHands SDK, OpenCode,
+  and Claude Code. Each trajectory resolves one harness from dataset metadata or a weighted policy,
+  while validation stays pinned to one harness so its metrics remain comparable across steps.
+- [2026/09/07] **SAO.** Single-rollout, critic-based training with decoupled GAE lambdas, a
+  frozen-attention critic, and DIS. See the [SAO guide](https://lego-rl.pages.dev/docs/run-training/sao).
+- [2026/08] **First public release.** Lego-RL brings Claude Code, OpenHands, and OpenCode into
+  online RL on real repositories, with native harnesses, executable verifier rewards, synchronous
+  or asynchronous training, and live run monitoring.
+
 <div align="center">
  <img src="docs/public/framework.png" width="820" alt="Lego-RL architecture">
 </div>
@@ -87,12 +98,6 @@ see the **[dashboard docs](https://lego-rl.pages.dev/docs/dashboard)**.
 ```bash
 bash webui/start_dashboard.sh
 ```
-
-## News
-
-- [2026/08] **First public release.** Lego-RL brings Claude Code, OpenHands, and OpenCode into
-  online RL on real repositories, with native harnesses, executable verifier rewards, synchronous
-  or asynchronous training, and live run monitoring.
 
 ## Key Features
 


### PR DESCRIPTION
Two features have landed since the public release and neither was visible from the top of the README — SAO was only discoverable from Key Features, mixed-harness training from nothing at all.

Adds one NEWS entry each, dated by its merge commit:

- `[2026/09/11]` Mixed-harness training — `d56c3bf` (#11)
- `[2026/09/07]` SAO — `9415cbb` (#9)

NEWS also moves above the architecture diagram, so what is new is visible before the reader scrolls past Results and the dashboard.

The `[2026/08]` release entry keeps its month-only date: it marks the announcement rather than a single commit (the initial commit `f97ab42` is 2026/07/28).

README only, +11/-6, no code or config touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LacAd5sY6keGxMy8Vj5SWE